### PR TITLE
Feature/optimise decode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bigdecimal = "0.3"
 
 [dev-dependencies]
 

--- a/src/cmdc/decode.rs
+++ b/src/cmdc/decode.rs
@@ -38,7 +38,7 @@ impl CmdcCodec {
         Ok((Container { header, fields }, idx))
     }
 
-    fn decode_header(&self, data: &[u8]) -> Result<(Header, usize), Box<dyn Error>> {
+    fn decode_header<'a>(&self, data: &'a [u8]) -> Result<(Header, usize), Box<dyn Error>> {
         let mut header = Header {
             version: 0,
             total_field: 0,

--- a/src/cmdc/decode.rs
+++ b/src/cmdc/decode.rs
@@ -7,7 +7,7 @@ use crate::mdd::Header;
 use std::error::Error;
 
 impl CmdcCodec {
-    pub fn decode_containers(&self, data: &[u8]) -> Result<Containers, Box<dyn Error>> {
+    pub fn decode_containers<'a>(&self, data: &'a [u8]) -> Result<Containers<'a>, Box<dyn Error>> {
         let mut containers = Containers { containers: vec![] };
 
         let mut idx = 0;
@@ -20,7 +20,10 @@ impl CmdcCodec {
         Ok(containers)
     }
 
-    fn decode_container(&self, data: &[u8]) -> Result<(Container, usize), Box<dyn Error>> {
+    fn decode_container<'a>(
+        &self,
+        data: &'a [u8],
+    ) -> Result<(Container<'a>, usize), Box<dyn Error>> {
         let mut idx = 0;
 
         // Decode Header
@@ -110,7 +113,7 @@ impl CmdcCodec {
         Ok((header, idx))
     }
 
-    fn decode_body(&self, data: &[u8]) -> Result<(Vec<Field>, usize), Box<dyn Error>> {
+    fn decode_body<'a>(&self, data: &'a [u8]) -> Result<(Vec<Field<'a>>, usize), Box<dyn Error>> {
         let mut fields = vec![];
 
         if data.is_empty() {
@@ -184,7 +187,7 @@ impl CmdcCodec {
 
                         mark = idx + 1;
                         let field = Field {
-                            data: field_data.to_vec(),
+                            data: field_data,
                             field_type: FieldType::Unknown,
                             value: None,
                             is_multi,
@@ -216,7 +219,7 @@ impl CmdcCodec {
         // println!("field_data: {:?}", std::str::from_utf8(field_data));
 
         let field = Field {
-            data: field_data.to_vec(),
+            data: field_data,
             field_type: FieldType::Unknown,
             value: None,
             is_multi,

--- a/src/cmdc/encode.rs
+++ b/src/cmdc/encode.rs
@@ -66,8 +66,7 @@ impl CmdcCodec {
             if i > 0 {
                 data.push(b',');
             }
-            // Use reference instead of clone for best performrance, but might be risky
-            data.extend(&field.data);
+            data.extend(field.data);
             // data.extend(field.data.clone());
         }
         data.push(b']');
@@ -95,10 +94,10 @@ mod tests {
                     ext_version: 2,
                 },
                 fields: vec![
-                    Field::raw("1".as_bytes().to_vec()),
-                    Field::raw("20".as_bytes().to_vec()),
-                    Field::raw("(5:three)".as_bytes().to_vec()),
-                    Field::raw("400000".as_bytes().to_vec()),
+                    Field::raw("1".as_bytes()),
+                    Field::raw("20".as_bytes()),
+                    Field::raw("(5:three)".as_bytes()),
+                    Field::raw("400000".as_bytes()),
                 ],
             }],
         };

--- a/src/cmdc/mod.rs
+++ b/src/cmdc/mod.rs
@@ -8,7 +8,7 @@ use std::error::Error;
 pub struct CmdcCodec {}
 
 impl Codec for CmdcCodec {
-    fn decode(&self, data: &[u8]) -> Result<Containers, Box<dyn Error>> {
+    fn decode<'a>(&self, data: &'a [u8]) -> Result<Containers<'a>, Box<dyn Error>> {
         self.decode_containers(data)
     }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -2,6 +2,6 @@ use crate::mdd::Containers;
 use std::error::Error;
 
 pub trait Codec {
-    fn decode(&self, data: &[u8]) -> Result<Containers, Box<dyn Error>>;
+    fn decode<'a>(&self, data: &'a [u8]) -> Result<Containers<'a>, Box<dyn Error>>;
     fn encode(&self, containers: &Containers) -> Result<Vec<u8>, Box<dyn Error>>;
 }

--- a/src/mdd.rs
+++ b/src/mdd.rs
@@ -1,15 +1,15 @@
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Containers<'a> {
     pub containers: Vec<Container<'a>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Container<'a> {
     pub header: Header,
     pub fields: Vec<Field<'a>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Header {
     pub version: u8,
     pub total_field: u8,
@@ -19,30 +19,41 @@ pub struct Header {
     pub ext_version: u16,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Field<'a> {
     // pub data: Vec<u8>,
     pub data: &'a [u8],
     pub field_type: FieldType,
-    pub value: Option<Box<dyn Value>>,
+    pub value: Option<Value<'a>>,
     pub is_multi: bool,
     pub is_container: bool,
 }
 
-pub trait Value: std::fmt::Debug {
-    fn to_string(&self) -> String;
-    fn to_int32(&self) -> i32;
-    fn to_uint32(&self) -> u32;
-    fn to_bool(&self) -> bool;
+// pub trait Value: std::fmt::Debug {
+//     fn to_string(&self) -> String;
+//     fn to_int32(&self) -> i32;
+//     fn to_uint32(&self) -> u32;
+//     fn to_bool(&self) -> bool;
+// }
+#[derive(Debug, Clone)]
+pub enum Value<'a> {
+    Struct(Containers<'a>),
+    String(String),
+    Int32(i32),
+    UInt32(u32),
+    Bool(bool),
+    Decimal(bigdecimal::BigDecimal),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum FieldType {
     Unknown,
+    Struct,
     String,
     Int32,
     UInt32,
     Bool,
+    Decimal,
 }
 
 impl<'a> Field<'a> {
@@ -53,6 +64,83 @@ impl<'a> Field<'a> {
             value: None,
             is_multi: false,
             is_container: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_string_field() {
+        let field_data = b"(6:foobar)";
+        let field = Field {
+            data: field_data,
+            field_type: FieldType::String,
+            value: Some(Value::String("foobar".to_string())),
+            is_multi: false,
+            is_container: false,
+        };
+        match field.value {
+            Some(Value::String(v)) => assert_eq!(v, "foobar"),
+            _ => panic!("Not a string"),
+        }
+    }
+
+    #[test]
+    fn test_get_int32_field() {
+        let field_data = b"-20";
+        let field = Field {
+            data: field_data,
+            field_type: FieldType::Int32,
+            value: Some(Value::Int32(-20)),
+            is_multi: false,
+            is_container: false,
+        };
+        match field.value {
+            Some(Value::Int32(v)) => assert_eq!(v, -20),
+            _ => panic!("Not a int32"),
+        }
+    }
+
+    #[test]
+    fn test_get_struct_field() {
+        let field_data = b"<1,18,0,-6,5222,2>[1,20,(5:three),400000]";
+        let field = Field {
+            data: field_data,
+            field_type: FieldType::Struct,
+            value: Some(Value::Struct(Containers {
+                containers: vec![Container {
+                    header: Header {
+                        version: 1,
+                        total_field: 18,
+                        depth: 0,
+                        key: -6,
+                        schema_version: 5222,
+                        ext_version: 2,
+                    },
+                    fields: vec![
+                        Field::raw("1".as_bytes()),
+                        Field::raw("20".as_bytes()),
+                        Field::raw("(5:three)".as_bytes()),
+                        Field::raw("400000".as_bytes()),
+                    ],
+                }],
+            })),
+            is_multi: false,
+            is_container: false,
+        };
+        match field.value {
+            Some(Value::Struct(v)) => {
+                assert_eq!(v.containers.len(), 1);
+                assert_eq!(v.containers[0].fields.len(), 4);
+                assert_eq!(v.containers[0].fields[0].data, b"1");
+                assert_eq!(v.containers[0].fields[1].data, b"20");
+                assert_eq!(v.containers[0].fields[2].data, b"(5:three)");
+                assert_eq!(v.containers[0].fields[3].data, b"400000");
+            }
+            _ => panic!("Not a struct"),
         }
     }
 }

--- a/src/mdd.rs
+++ b/src/mdd.rs
@@ -1,12 +1,12 @@
 #[derive(Debug)]
-pub struct Containers {
-    pub containers: Vec<Container>,
+pub struct Containers<'a> {
+    pub containers: Vec<Container<'a>>,
 }
 
 #[derive(Debug)]
-pub struct Container {
+pub struct Container<'a> {
     pub header: Header,
-    pub fields: Vec<Field>,
+    pub fields: Vec<Field<'a>>,
 }
 
 #[derive(Debug)]
@@ -20,8 +20,9 @@ pub struct Header {
 }
 
 #[derive(Debug)]
-pub struct Field {
-    pub data: Vec<u8>,
+pub struct Field<'a> {
+    // pub data: Vec<u8>,
+    pub data: &'a [u8],
     pub field_type: FieldType,
     pub value: Option<Box<dyn Value>>,
     pub is_multi: bool,
@@ -44,8 +45,8 @@ pub enum FieldType {
     Bool,
 }
 
-impl Field {
-    pub fn raw(data: Vec<u8>) -> Self {
+impl<'a> Field<'a> {
+    pub fn raw(data: &'a [u8]) -> Self {
         Field {
             data,
             field_type: FieldType::Unknown,


### PR DESCRIPTION
* replace `field.data` from `Vec<u8>` to `&`a [u8]` to avoid memcopy during `decode()` which result in significant performance improvement
* replace `trait Value` to `enum Value`
* annotate mdd structs with `Clone` 